### PR TITLE
List local posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ writeas-cli
 ===========
 Command line interface for [Write.as](https://write.as) and [Write.as on Tor](http://writeas7pm7rcdqg.onion/). Works on Windows, OS X, and Linux.
 
-Like the [Android app](https://play.google.com/store/apps/details?id=com.abunchtell.writeas), the command line client keeps track of the posts you make, so future editing / deleting is easier than [doing it with cURL](http://cmd.write.as/). It is currently **ALPHA**, so only basic functionality is available. But the goal is for this to hold the logic behind any future GUI app we build for the desktop.
+Like the [Android app](https://play.google.com/store/apps/details?id=com.abunchtell.writeas), the command line client keeps track of the posts you make, so future editing / deleting is easier than [doing it with cURL](http://cmd.write.as/). The goal is for this to serve as the backend for any future GUI app we build for the desktop.
+
+It is currently **alpha**, so a) functionality is basic and b) everything is subject to change — i.e., watch the [changelog](https://write.as/changelog-cli.html).
 
 ## Usage
 
@@ -14,6 +16,7 @@ COMMANDS:
    delete   Delete a post
    get      Read a raw post
    add      Add a post locally
+   list     List local posts
    help, h  Shows a list of commands or help for one command
    
 GLOBAL OPTIONS:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ COMMANDS:
    post     Alias for default action: create post from stdin
    delete   Delete a post
    get      Read a raw post
+   add      Add a post locally for easy modification
    help, h  Shows a list of commands or help for one command
    
 GLOBAL OPTIONS:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ COMMANDS:
    post     Alias for default action: create post from stdin
    delete   Delete a post
    get      Read a raw post
-   add      Add a post locally for easy modification
+   add      Add a post locally
    help, h  Shows a list of commands or help for one command
    
 GLOBAL OPTIONS:

--- a/utils/fileutils.go
+++ b/utils/fileutils.go
@@ -30,6 +30,27 @@ func WriteData(path string, data []byte) {
 	}
 }
 
+func ReadData(p string) *[]string {
+	f, err := os.Open(p)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	lines := []string{}
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil
+	}
+
+	return &lines
+}
+
 func RemoveLine(p, startsWith string) {
 	f, err := os.Open(p)
 	if err != nil {

--- a/writeas/cli.go
+++ b/writeas/cli.go
@@ -102,6 +102,21 @@ func main() {
 			Usage:  "Add a post locally for easy modification",
 			Action: cmdAdd,
 		},
+		{
+			Name:   "list",
+			Usage:  "List local posts",
+			Action: cmdList,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "id",
+					Usage: "Show list with post IDs (default)",
+				},
+				cli.BoolFlag{
+					Name:  "url",
+					Usage: "Show list with URLs",
+				},
+			},
+		},
 	}
 
 	app.Run(os.Args)
@@ -216,6 +231,24 @@ func cmdAdd(c *cli.Context) {
 	}
 
 	addPost(friendlyId, token)
+}
+
+func cmdList(c *cli.Context) {
+	urls := c.Bool("url")
+	ids := c.Bool("id")
+
+	var p Post
+	posts := getPosts()
+	for i := range *posts {
+		p = (*posts)[len(*posts)-1-i]
+		if ids || !urls {
+			fmt.Printf("%s ", p.ID)
+		}
+		if urls {
+			fmt.Printf("https://write.as/%s ", p.ID)
+		}
+		fmt.Print("\n")
+	}
 }
 
 func client(read, tor bool, path, query string) (string, *http.Client) {

--- a/writeas/cli.go
+++ b/writeas/cli.go
@@ -97,6 +97,11 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:   "add",
+			Usage:  "Add a post locally for easy modification",
+			Action: cmdAdd,
+		},
 	}
 
 	app.Run(os.Args)
@@ -200,6 +205,17 @@ func cmdGet(c *cli.Context) {
 	}
 
 	DoFetch(friendlyId, tor)
+}
+
+func cmdAdd(c *cli.Context) {
+	friendlyId := c.Args().Get(0)
+	token := c.Args().Get(1)
+	if friendlyId == "" || token == "" {
+		fmt.Println("usage: writeas add <postId> <token>")
+		os.Exit(1)
+	}
+
+	addPost(friendlyId, token)
 }
 
 func client(read, tor bool, path, query string) (string, *http.Client) {

--- a/writeas/cli.go
+++ b/writeas/cli.go
@@ -99,7 +99,7 @@ func main() {
 		},
 		{
 			Name:   "add",
-			Usage:  "Add a post locally for easy modification",
+			Usage:  "Add a post locally",
 			Action: cmdAdd,
 		},
 		{

--- a/writeas/posts.go
+++ b/writeas/posts.go
@@ -13,6 +13,11 @@ const (
 	SEPARATOR  = `|`
 )
 
+type Post struct {
+	ID        string
+	EditToken string
+}
+
 func userDataDir() string {
 	return filepath.Join(parentDataDir(), DATA_DIR_NAME)
 }
@@ -62,4 +67,22 @@ func tokenFromID(id string) string {
 
 func removePost(id string) {
 	fileutils.RemoveLine(filepath.Join(userDataDir(), POSTS_FILE), id)
+}
+
+func getPosts() *[]Post {
+	lines := fileutils.ReadData(filepath.Join(userDataDir(), POSTS_FILE))
+
+	posts := []Post{}
+	parts := make([]string, 2)
+
+	for _, l := range *lines {
+		parts = strings.Split(l, SEPARATOR)
+		if len(parts) < 2 {
+			continue
+		}
+		posts = append(posts, Post{ID: parts[0], EditToken: parts[1]})
+	}
+
+	return &posts
+
 }


### PR DESCRIPTION
Lists local posts with `writeas list` (issue #2)

Includes additional display flags that can be used cumulatively: `--id` and `--url`, and the ability to add new posts locally by supplying the post ID and edit token.