### PR TITLE
style: Run goimports on all Go files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,10 +22,19 @@ Please follow our coding conventions below and make sure all of your commits are
 
 We strive for consistency above all. Reading the small codebase should give you a good idea of the conventions we follow.
 
-* We use `go fmt` before committing anything
+* We use `goimports` before committing anything
 * We aim to document all exported entities
 * Go files are broken up into logical functional components
 * General functions are extracted into modules when possible
+
+### Import Groups
+
+We aim for two import groups:
+
+* Standard library imports
+* Everything else
+
+`goimports` already does this for you along with running `go fmt`.
 
 ## Design conventions
 

--- a/cmd/writeas/api.go
+++ b/cmd/writeas/api.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/atotto/clipboard"
 	"github.com/writeas/web-core/posts"
 	"github.com/writeas/writeas-cli/fileutils"
-	"go.code.as/writeas.v2"
-	"gopkg.in/urfave/cli.v1"
-	"path/filepath"
+	writeas "go.code.as/writeas.v2"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 const (

--- a/cmd/writeas/cli.go
+++ b/cmd/writeas/cli.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"bufio"
-	"go.code.as/writeas.v2"
-	"gopkg.in/urfave/cli.v1"
 	"io"
 	"log"
 	"os"
+
+	writeas "go.code.as/writeas.v2"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 // API constants for communicating with Write.as.

--- a/cmd/writeas/commands.go
+++ b/cmd/writeas/commands.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/howeyc/gopass"
-	"github.com/writeas/writeas-cli/fileutils"
-	"gopkg.in/urfave/cli.v1"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/howeyc/gopass"
+	"github.com/writeas/writeas-cli/fileutils"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 func cmdPost(c *cli.Context) error {

--- a/cmd/writeas/logging.go
+++ b/cmd/writeas/logging.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"gopkg.in/urfave/cli.v1"
 	"os"
+
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 // Info logs general diagnostic messages, shown only when the -v or --verbose

--- a/cmd/writeas/options.go
+++ b/cmd/writeas/options.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/cloudfoundry/jibber_jabber"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 func userAgent(c *cli.Context) string {

--- a/cmd/writeas/posts.go
+++ b/cmd/writeas/posts.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/writeas/writeas-cli/fileutils"
-	"go.code.as/writeas.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/writeas/writeas-cli/fileutils"
+	writeas "go.code.as/writeas.v2"
 )
 
 const (

--- a/cmd/writeas/posts_nix.go
+++ b/cmd/writeas/posts_nix.go
@@ -4,8 +4,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/mitchellh/go-homedir"
 	"os/exec"
+
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 const (

--- a/cmd/writeas/sync.go
+++ b/cmd/writeas/sync.go
@@ -3,11 +3,12 @@ package main
 import (
 	//"github.com/writeas/writeas-cli/sync"
 	"fmt"
-	"github.com/writeas/writeas-cli/fileutils"
-	"gopkg.in/urfave/cli.v1"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/writeas/writeas-cli/fileutils"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 const (

--- a/cmd/writeas/tor.go
+++ b/cmd/writeas/tor.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"code.as/core/socks"
 	"fmt"
 	"net/http"
+
+	"code.as/core/socks"
 )
 
 var (

--- a/cmd/writeas/userconfig.go
+++ b/cmd/writeas/userconfig.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/writeas/writeas-cli/fileutils"
-	"go.code.as/writeas.v2"
-	"gopkg.in/ini.v1"
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/writeas/writeas-cli/fileutils"
+	writeas "go.code.as/writeas.v2"
+	ini "gopkg.in/ini.v1"
 )
 
 const (


### PR DESCRIPTION
As per #20, this runs goimports on all Go files and updates the Coding
Conventions section of the CONTRIBUTING doc.