### PR TITLE
Add writeas config command

### DIFF
--- a/cmd/writeas/cli.go
+++ b/cmd/writeas/cli.go
@@ -289,13 +289,37 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:   "config",
+			Usage:  "Get and set options",
+			UsageText: "config name [value]\n   writeas config [command options]",
+			Action: cmdOptions,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "edit, e",
+					Usage: "Opens an editor to modify the config file",
+				},
+				cli.BoolFlag{
+					Name:  "list, l",
+					Usage: "List all variables set in config file, along with their values",
+				},
+				cli.BoolFlag{
+					Name:  "list-all, a",
+					Usage: "List all config variables, along with their values",
+				},
+				cli.BoolFlag{
+					Name:  "verbose, v",
+					Usage: "Make the operation more talkative",
+				},
+			},
+		},
 	}
 
 	cli.CommandHelpTemplate = `NAME:
    {{.Name}} - {{.Usage}}
 
 USAGE:
-   writeas {{.Name}}{{if .Flags}} [command options]{{end}} [arguments...]{{if .Description}}
+   writeas {{if .UsageText}}{{.UsageText}}{{else}}{{.Name}}{{if .Flags}} [command options]{{end}} [arguments...]{{end}}{{if .Description}}
 
 DESCRIPTION:
    {{.Description}}{{end}}{{if .Flags}}

--- a/cmd/writeas/userconfig.go
+++ b/cmd/writeas/userconfig.go
@@ -7,6 +7,10 @@ import (
 	"gopkg.in/ini.v1"
 	"io/ioutil"
 	"path/filepath"
+	"reflect"
+	"fmt"
+	"os"
+	"strings"
 )
 
 const (
@@ -85,6 +89,100 @@ func saveUser(u *writeas.AuthUser) error {
 	err = ioutil.WriteFile(filepath.Join(userDataDir(), userFile), userJSON, 0600)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// Prints all values of the given struct
+// For subfields: the field name is separated with dots (ex: Posts.Directory=)
+func printConfig(x interface{}, prefix string, showEmptyValues bool) {
+	values := reflect.ValueOf(x)
+
+	if values.Kind() == reflect.Ptr {
+		values = values.Elem()
+	}
+	typ := values.Type()
+
+	for i := 0; i < typ.NumField(); i++ {
+		val  := values.Field(i)
+		name := typ.Field(i).Name
+
+		if prefix != "" {
+			name = prefix + "." + name
+		}
+		if(val.Kind() == reflect.Struct) {
+			printConfig(val.Interface(), name, showEmptyValues)
+		} else {
+			if showEmptyValues || val.Interface() != reflect.Zero(val.Type()).Interface() {
+				fmt.Printf("%s=%v\n", name, val)
+			}
+		}
+	}
+}
+
+// Get the value of a given field
+// For subfields: the name should be separated with dots (ex: Posts.Directory)
+func getConfigField(x interface{}, name string) (*reflect.Value, error) {
+	path   := strings.Split(name, ".")
+	values := reflect.ValueOf(x)
+
+	if values.Kind() == reflect.Ptr {
+		values = values.Elem()
+	}
+	for _, part := range path {
+		values = values.FieldByName(part)
+
+		if !values.IsValid() {
+			err := fmt.Errorf("error: key does not contain a section: %v", name)
+			return nil, err
+		}
+	}
+	if values.Kind() == reflect.Struct {
+		err := fmt.Errorf("error: key does not contain a section: %v", name)
+		return nil, err
+	}
+	return &values, nil
+}
+
+// Opens an editor to modify the config file
+func composeConfig() error {
+	filename := filepath.Join(userDataDir(), userConfigFile)
+
+	// Open the editor
+	cmd := editPostCmd(filename)
+	if cmd == nil {
+		fmt.Println(noEditorErr)
+		return nil
+	}
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Start(); err != nil {
+		if debug {
+			panic(err)
+		} else {
+			Errorln("Error starting editor: %s", err)
+			return nil
+		}
+	}
+
+	// Wait until the editor is closed
+	if err := cmd.Wait(); err != nil {
+		if debug {
+			panic(err)
+		} else {
+			Errorln("Editor finished with error: %s", err)
+			return nil
+		}
+	}
+
+	// Check if the config file is valid
+	_, err := loadConfig()
+	if err != nil {
+		if debug {
+			panic(err)
+		} else {
+			Errorln("Error loading config: %s", err)
+			return nil
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Adds the command "config", to be able to easily edit the user configurations.  
I know you didn't ask for it, feel free to reject it.  
If you don't, here's some reservations that I have:

* I don't understand how the errors are handled
  - commands.go:
    ```
    return err
    ```
    ```
    InfolnQuit("msg")
    ```
    ```
    Errorln("msg")
    return cli.NewExitError("", 1)
    ```
    ```
    return cli.NewExitError("msg")
    ```
    ```
    ErrorlnQuit("msg")
    ```

  - fonts.go:
    ```
    fmt.Print("msg")
    ```

  - options.go:
    ```
    Info(c, "msg")
    ```

  - posts.go:
    ```
    if debug {
      panic(err)
    } else {
      Errorln("msg")
      return
    }
    ```
    ```
    return fmt.Errorf("msg")
    ```

  Basically, I don't understand in which cases errors should be returned rather than printed, and with which method :/

* When the user doesn't give the right options / arguments:  
  Shouldn't we print the command usage and its options, using `cli.ShowSubcommandHelp(c)` (the same output as `writeas COMMAND --help`) and putting the usage in the field `UsageText` (cli.go), rather than calling `cli.NewExitError("usage: writeas ...", 1)`?

Looking forward to your feedback!