### PR TITLE
Add option to authenticate/work with different host

### DIFF
--- a/cmd/writeas/api.go
+++ b/cmd/writeas/api.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/atotto/clipboard"
 	"github.com/writeas/web-core/posts"
 	"github.com/writeas/writeas-cli/fileutils"
 	"go.code.as/writeas.v2"
 	"gopkg.in/urfave/cli.v1"
-	"path/filepath"
 )
 
 const (
@@ -40,12 +41,17 @@ func newClient(c *cli.Context, authRequired bool) (*writeas.Client, error) {
 		} else {
 			client = writeas.NewClient()
 		}
+
+		if c.String("host") != "" {
+			client.SetBaseUrl(c.String("host") + "/api")
+		}
 	}
 	client.UserAgent = userAgent(c)
 	// TODO: load user into var shared across the app
 	u, _ := loadUser()
 	if u != nil {
 		client.SetToken(u.AccessToken)
+		client.SetBaseUrl(u.BaseURL)
 	} else if authRequired {
 		return nil, fmt.Errorf("Not currently logged in. Authenticate with: writeas auth <username>")
 	}
@@ -177,7 +183,7 @@ func DoDelete(c *cli.Context, friendlyID, token string, tor bool) error {
 }
 
 func DoLogIn(c *cli.Context, username, password string) error {
-	cl := client(userAgent(c), isTor(c))
+	cl, _ := newClient(c, false)
 
 	u, err := cl.LogIn(username, password)
 	if err != nil {

--- a/cmd/writeas/cli.go
+++ b/cmd/writeas/cli.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"bufio"
-	"go.code.as/writeas.v2"
-	"gopkg.in/urfave/cli.v1"
 	"io"
 	"log"
 	"os"
+
+	"go.code.as/writeas.v2"
+	"gopkg.in/urfave/cli.v1"
 )
 
 // API constants for communicating with Write.as.
@@ -254,6 +255,10 @@ func main() {
 			Usage:  "Authenticate with Write.as",
 			Action: cmdAuth,
 			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "host",
+					Usage: "Set host address",
+				},
 				cli.BoolFlag{
 					Name:  "tor, t",
 					Usage: "Authenticate via Tor hidden service",


### PR DESCRIPTION
Depends on: https://github.com/writeas/go-writeas/pull/16 which stores the baseUrl when authenticating and then uses that for all other requests.

One thing I haven't been able to figure out is why the post doesn't work to writefreely instance.. Always returns a 401.  I've verified its getting the token.. but looks like for some reason not matching.. because sql isn't getting a match.