### PR TITLE
make config directory configurable

### DIFF
--- a/api/posts.go
+++ b/api/posts.go
@@ -27,8 +27,8 @@ type Post struct {
 	EditToken string
 }
 
-func AddPost(id, token string) error {
-	f, err := os.OpenFile(filepath.Join(config.UserDataDir(), postsFile), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+func AddPost(c *cli.Context, id, token string) error {
+	f, err := os.OpenFile(filepath.Join(config.UserDataDir(c.App.ExtraInfo()["configDir"]), postsFile), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return fmt.Errorf("Error creating local posts list: %s", err)
 	}
@@ -43,8 +43,8 @@ func AddPost(id, token string) error {
 	return nil
 }
 
-func TokenFromID(id string) string {
-	post := fileutils.FindLine(filepath.Join(config.UserDataDir(), postsFile), id)
+func TokenFromID(c *cli.Context, id string) string {
+	post := fileutils.FindLine(filepath.Join(config.UserDataDir(c.App.ExtraInfo()["configDir"]), postsFile), id)
 	if post == "" {
 		return ""
 	}
@@ -57,12 +57,12 @@ func TokenFromID(id string) string {
 	return parts[1]
 }
 
-func removePost(id string) {
-	fileutils.RemoveLine(filepath.Join(config.UserDataDir(), postsFile), id)
+func removePost(path, id string) {
+	fileutils.RemoveLine(filepath.Join(config.UserDataDir(path), postsFile), id)
 }
 
-func GetPosts() *[]Post {
-	lines := fileutils.ReadData(filepath.Join(config.UserDataDir(), postsFile))
+func GetPosts(c *cli.Context) *[]Post {
+	lines := fileutils.ReadData(filepath.Join(config.UserDataDir(c.App.ExtraInfo()["configDir"]), postsFile))
 
 	posts := []Post{}
 

--- a/api/sync.go
+++ b/api/sync.go
@@ -19,13 +19,13 @@ const (
 )
 
 func CmdPull(c *cli.Context) error {
-	cfg, err := config.LoadConfig(config.UserDataDir())
+	cfg, err := config.LoadConfig(config.UserDataDir(c.App.ExtraInfo()["configDir"]))
 	if err != nil {
 		return err
 	}
 	// Create posts directory if needed
 	if cfg.Posts.Directory == "" {
-		syncSetUp(cfg)
+		syncSetUp(c.App.ExtraInfo()["configDir"], cfg)
 	}
 
 	// Fetch posts
@@ -79,10 +79,10 @@ func CmdPull(c *cli.Context) error {
 	return nil
 }
 
-func syncSetUp(cfg *config.UserConfig) error {
+func syncSetUp(path string, cfg *config.UserConfig) error {
 	// Get user information and fail early (before we make the user do
 	// anything), if we're going to
-	u, err := config.LoadUser(config.UserDataDir())
+	u, err := config.LoadUser(config.UserDataDir(path))
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func syncSetUp(cfg *config.UserConfig) error {
 
 	// Save preference
 	cfg.Posts.Directory = dir
-	err = config.SaveConfig(config.UserDataDir(), cfg)
+	err = config.SaveConfig(config.UserDataDir(path), cfg)
 	if err != nil {
 		if config.Debug() {
 			log.Errorln("Unable to save config: %s", err)

--- a/cmd/writeas/config_nix.go
+++ b/cmd/writeas/config_nix.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package main
+
+var appInfo = map[string]string{
+	"configDir": ".writeas",
+}

--- a/cmd/writeas/config_win.go
+++ b/cmd/writeas/config_win.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package main
+
+var appInfo = map[string]string{
+	"configDir": "Write.as",
+}

--- a/cmd/writeas/main.go
+++ b/cmd/writeas/main.go
@@ -11,8 +11,7 @@ import (
 )
 
 func main() {
-	initialize()
-
+	initialize(appInfo["configDir"])
 	cli.VersionFlag = cli.BoolFlag{
 		Name:  "version, V",
 		Usage: "print the version",
@@ -28,6 +27,9 @@ func main() {
 			Name:  "Write.as",
 			Email: "hello@write.as",
 		},
+	}
+	app.ExtraInfo = func() map[string]string {
+		return appInfo
 	}
 	app.Action = commands.CmdPost
 	app.Flags = config.PostFlags
@@ -243,14 +245,13 @@ OPTIONS:
    {{range .Flags}}{{.}}
    {{end}}{{ end }}
 `
-
 	app.Run(os.Args)
 }
 
-func initialize() {
+func initialize(dataDirName string) {
 	// Ensure we have a data directory to use
-	if !config.DataDirExists() {
-		err := config.CreateDataDir()
+	if !config.DataDirExists(dataDirName) {
+		err := config.CreateDataDir(dataDirName)
 		if err != nil {
 			if config.Debug() {
 				panic(err)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -65,7 +65,7 @@ func CmdPublish(c *cli.Context) error {
 	}
 
 	// Save post to posts folder
-	cfg, err := config.LoadConfig(config.UserDataDir())
+	cfg, err := config.LoadConfig(config.UserDataDir(c.App.ExtraInfo()["configDir"]))
 	if cfg.Posts.Directory != "" {
 		err = api.WritePost(cfg.Posts.Directory, p)
 		if err != nil {
@@ -82,10 +82,10 @@ func CmdDelete(c *cli.Context) error {
 		return cli.NewExitError("usage: writeas delete <postId> [<token>]", 1)
 	}
 
-	u, _ := config.LoadUser(config.UserDataDir())
+	u, _ := config.LoadUser(config.UserDataDir(c.App.ExtraInfo()["configDir"]))
 	if token == "" {
 		// Search for the token locally
-		token = api.TokenFromID(friendlyID)
+		token = api.TokenFromID(c, friendlyID)
 		if token == "" && u == nil {
 			log.Errorln("Couldn't find an edit token locally. Did you create this post here?")
 			log.ErrorlnQuit("If you have an edit token, use: writeas delete %s <token>", friendlyID)
@@ -108,7 +108,7 @@ func CmdDelete(c *cli.Context) error {
 	}
 
 	// Delete local file, if necessary
-	cfg, err := config.LoadConfig(config.UserDataDir())
+	cfg, err := config.LoadConfig(config.UserDataDir(c.App.ExtraInfo()["configDir"]))
 	if cfg.Posts.Directory != "" {
 		// TODO: handle deleting blog posts
 		err = fileutils.DeleteFile(filepath.Join(cfg.Posts.Directory, friendlyID+api.PostFileExt))
@@ -127,10 +127,10 @@ func CmdUpdate(c *cli.Context) error {
 		return cli.NewExitError("usage: writeas update <postId> [<token>]", 1)
 	}
 
-	u, _ := config.LoadUser(config.UserDataDir())
+	u, _ := config.LoadUser(config.UserDataDir(c.App.ExtraInfo()["configDir"]))
 	if token == "" {
 		// Search for the token locally
-		token = api.TokenFromID(friendlyID)
+		token = api.TokenFromID(c, friendlyID)
 		if token == "" && u == nil {
 			log.Errorln("Couldn't find an edit token locally. Did you create this post here?")
 			log.ErrorlnQuit("If you have an edit token, use: writeas update %s <token>", friendlyID)
@@ -179,7 +179,7 @@ func CmdAdd(c *cli.Context) error {
 		return cli.NewExitError("usage: writeas add <postId> <token>", 1)
 	}
 
-	err := api.AddPost(friendlyID, token)
+	err := api.AddPost(c, friendlyID, token)
 	return err
 }
 
@@ -188,7 +188,7 @@ func CmdList(c *cli.Context) error {
 	ids := c.Bool("id")
 
 	var p api.Post
-	posts := api.GetPosts()
+	posts := api.GetPosts(c)
 	for i := range *posts {
 		p = (*posts)[len(*posts)-1-i]
 		if ids || !urls {
@@ -213,7 +213,7 @@ func CmdList(c *cli.Context) error {
 
 func CmdAuth(c *cli.Context) error {
 	// Check configuration
-	u, err := config.LoadUser(config.UserDataDir())
+	u, err := config.LoadUser(config.UserDataDir(c.App.ExtraInfo()["configDir"]))
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("couldn't load config: %v", err), 1)
 	}

--- a/config/directories.go
+++ b/config/directories.go
@@ -7,14 +7,14 @@ import (
 	"github.com/writeas/writeas-cli/fileutils"
 )
 
-func UserDataDir() string {
+func UserDataDir(dataDirName string) string {
 	return filepath.Join(parentDataDir(), dataDirName)
 }
 
-func DataDirExists() bool {
-	return fileutils.Exists(UserDataDir())
+func DataDirExists(dataDirName string) bool {
+	return fileutils.Exists(UserDataDir(dataDirName))
 }
 
-func CreateDataDir() error {
-	return os.Mkdir(UserDataDir(), 0700)
+func CreateDataDir(dataDirName string) error {
+	return os.Mkdir(UserDataDir(dataDirName), 0700)
 }

--- a/config/files_nix.go
+++ b/config/files_nix.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	dataDirName = ".writeas"
 	NoEditorErr = "Couldn't find default editor. Try setting $EDITOR environment variable in ~/.profile"
 )
 

--- a/config/files_win.go
+++ b/config/files_win.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	dataDirName = "Write.as"
 	NoEditorErr = "Error getting default editor. You shouldn't see this, so let us know you did: hello@write.as"
 )
 


### PR DESCRIPTION
this adds a configurable directory, currently within the users path for
the configuration, user and post data to be saved.

it is accessible down the stack of the application via the cli.Context,
specificaly c.App.ExtraData which is a function that returns a map of
[string]string under the key 'configDir".