### PR TITLE
revert posts listing style to v1.2

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -84,19 +84,23 @@ user     An Example Blog
 dev      My Dev Log
 ```
 
-#### List all published posts
+#### List posts
 
-This lists all posts you've published from your device, as well as any published by the authenticated user.
+This lists all posts you've published from your device
 
 Pass the `--url` flag to show the list with full post URLs, and the `--md` flag to return URLs with Markdown enabled.
 
+To see post IDs with their Edit Tokens pass the `--v` flag.
+
 ```bash
 $ writeas posts
-Local     ID             Token                             
-unsynced  aaaazzzzzzzza  dhuieoj23894jhf984hdfs9834hdf84j  
+aaaazzzzzzzza
 
-Account   ID                Title                         
-synced    mmmmmmmm33333333  This is a post                
+$ writeas posts -url
+https://write.as/aaaazzzzzzzza
+
+$ writeas posts -v
+aaaazzzzzzzza | dhuieoj23894jhf984hdfs9834hdf84j
 ```
 
 #### Delete a post

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -100,7 +100,8 @@ $ writeas posts -url
 https://write.as/aaaazzzzzzzza
 
 $ writeas posts -v
-aaaazzzzzzzza | dhuieoj23894jhf984hdfs9834hdf84j
+ID              Token
+aaaazzzzzzzza   dhuieoj23894jhf984hdfs9834hdf84j
 ```
 
 #### Delete a post

--- a/cmd/writeas/main.go
+++ b/cmd/writeas/main.go
@@ -153,7 +153,7 @@ func main() {
 		{
 			Name:        "posts",
 			Usage:       "List all of your posts",
-			Description: "This will list only local posts when not currently authenticated. To list remote posts as well, first run: writeas auth <username>.",
+			Description: "This will list only local posts.",
 			Action:      commands.CmdListPosts,
 			Flags: []cli.Flag{
 				cli.BoolFlag{
@@ -167,6 +167,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "url",
 					Usage: "Show list with URLs",
+				},
+				cli.BoolFlag{
+					Name:  "verbose, v",
+					Usage: "Show verbose post listing, including Edit Tokens",
 				},
 			},
 		}, {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -169,10 +169,31 @@ func CmdListPosts(c *cli.Context) error {
 	details := c.Bool("v")
 
 	posts := api.GetPosts(c)
+
+	if details {
+		var p api.Post
+		tw := tabwriter.NewWriter(os.Stdout, 10, 0, 2, ' ', tabwriter.TabIndent)
+		numPosts := len(*posts)
+		if ids || !urls && numPosts != 0 {
+			fmt.Fprintf(tw, "%s\t%s\t\n", "ID", "Token")
+		} else if numPosts != 0 {
+			fmt.Fprintf(tw, "%s\t%s\t\n", "URL", "Token")
+		} else {
+			fmt.Fprintf(tw, "No local posts found\n")
+		}
+		for i := range *posts {
+			p = (*posts)[numPosts-1-i]
+			if ids || !urls {
+				fmt.Fprintf(tw, "%s\t%s\t\n", p.ID, p.EditToken)
+			} else {
+				fmt.Fprintf(tw, "%s\t%s\t\n", getPostURL(c, p.ID), p.EditToken)
+			}
+		}
+		return tw.Flush()
+	}
+
 	for _, p := range *posts {
-		if details {
-			fmt.Printf("%s | %s\n", p.ID, p.EditToken)
-		} else if ids || !urls {
+		if ids || !urls {
 			fmt.Printf("%s\n", p.ID)
 		} else {
 			fmt.Printf("%s\n", getPostURL(c, p.ID))

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -166,53 +166,19 @@ func CmdAdd(c *cli.Context) error {
 func CmdListPosts(c *cli.Context) error {
 	urls := c.Bool("url")
 	ids := c.Bool("id")
+	details := c.Bool("v")
 
-	var p api.Post
 	posts := api.GetPosts(c)
-	tw := tabwriter.NewWriter(os.Stdout, 10, 0, 2, ' ', tabwriter.TabIndent)
-	numPosts := len(*posts)
-	if ids || !urls && numPosts != 0 {
-		fmt.Fprintf(tw, "Local\t%s\t%s\t\n", "ID", "Token")
-	} else if numPosts != 0 {
-		fmt.Fprintf(tw, "Local\t%s\t%s\t\n", "URL", "Token")
-	} else {
-		fmt.Fprintf(tw, "No local posts found\n")
-	}
-	for i := range *posts {
-		p = (*posts)[numPosts-1-i]
-		if ids || !urls {
-			fmt.Fprintf(tw, "unsynced\t%s\t%s\t\n", p.ID, p.EditToken)
+	for _, p := range *posts {
+		if details {
+			fmt.Printf("%s | %s\n", p.ID, p.EditToken)
+		} else if ids || !urls {
+			fmt.Printf("%s\n", p.ID)
 		} else {
-			fmt.Fprintf(tw, "unsynced\t%s\t%s\t\n", getPostURL(c, p.ID), p.EditToken)
+			fmt.Printf("%s\n", getPostURL(c, p.ID))
 		}
 	}
-	u, _ := config.LoadUser(config.UserDataDir(c.App.ExtraInfo()["configDir"]))
-	if u != nil {
-		remotePosts, err := api.GetUserPosts(c)
-		if err != nil {
-			fmt.Println(err)
-		}
-
-		if len(remotePosts) > 0 {
-			identifier := "URL"
-			if ids || !urls {
-				identifier = "ID"
-			}
-			fmt.Fprintf(tw, "\nAccount\t%s\t%s\t\n", identifier, "Title")
-		}
-		for _, p := range remotePosts {
-			identifier := getPostURL(c, p.ID)
-			if ids || !urls {
-				identifier = p.ID
-			}
-			synced := "unsynced"
-			if p.Synced {
-				synced = "synced"
-			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t\n", synced, identifier, p.Title)
-		}
-	}
-	return tw.Flush()
+	return nil
 }
 
 func getPostURL(c *cli.Context, slug string) string {


### PR DESCRIPTION
this changes the posts listing output back to v1.2 style

also removes remote posts listing for now.
posts with edit tokens are behind `-v` flag.